### PR TITLE
Update aws sdk to include WIP and link to beta version on nuget

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Project | NuGet Install Command | .NET Core Support | ASP.NET Core Support | Web
 [Azure SDK](https://github.com/Azure/azure-sdk-for-net) |  | ? | ? | [azure.microsoft.com](https://azure.microsoft.com/en-us/develop/net/)
 [Azure Storage SDK](https://github.com/Azure/azure-storage-net) | install-package WindowsAzure.Storage -Pre | Yes | Yes | [azure.microsoft.com](https://azure.microsoft.com/en-us/documentation/services/storage/)
 [Microsoft.Hadoop.Client](https://github.com/Azure/azure-sdk-for-net) |  |  |  | 
-[AWS SDK](https://github.com/aws/aws-sdk-net) |  | ? | ? | 
+[AWS SDK](https://github.com/aws/aws-sdk-net) | Install-Package AWSSDK.Core -Pre | [WIP](https://www.nuget.org/packages/AWSSDK.Core/3.2.5-beta) | [WIP](https://www.nuget.org/packages/AWSSDK.Core/3.2.5-beta) | 
 [C# BitTorrent library](https://github.com/cheatdeath/research-bittorrent) |  | [No](https://github.com/jpsingleton/ANCLAFS/issues/6) | [No](https://github.com/jpsingleton/ANCLAFS/issues/6) | [cheatdeath.github.io/research-bittorrent-doc](https://cheatdeath.github.io/research-bittorrent-doc)
 [FluentScheduler](https://github.com/fluentscheduler/FluentScheduler) |  | Yes | Yes |
 [Quartz.NET](https://github.com/quartznet/quartznet) |  | [WIP](https://github.com/quartznet/quartznet/issues/355) | [WIP](https://github.com/quartznet/quartznet/issues/355) | [quartz-scheduler.net](http://www.quartz-scheduler.net/)


### PR DESCRIPTION
AWS.Core and related dependencies are currently in Beta. Appear to be working (only tested S3 and SQS but it worked for NetStandard15)
