### PR TITLE
Update Bond, as it supports .NET Core as of 5.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Project | NuGet Install Command | .NET Core Support | ASP.NET Core Support | Web
 [Jil](https://github.com/kevin-montrose/Jil) |  | Yes | Yes | 
 [NetJSON](https://github.com/rpgmaker/NetJSON) |  | [WIP](https://github.com/rpgmaker/NetJSON/issues/105) | [WIP](https://github.com/rpgmaker/NetJSON/issues/105) | 
 [ServiceStack.Text](https://github.com/ServiceStack/ServiceStack.Text) |  | No | No | 
-[Bond](https://github.com/Microsoft/bond) |  | [WIP](https://github.com/Microsoft/bond/issues/166) | [WIP](https://github.com/Microsoft/bond/issues/166) | 
+[Bond](https://github.com/Microsoft/bond) |  | Yes | Yes |
 [protobuf-net](https://github.com/mgravell/protobuf-net) | Install-Package protobuf-net | [No](https://github.com/mgravell/protobuf-net/issues/159) | [No](https://github.com/mgravell/protobuf-net/issues/159)
 
 ## Testing


### PR DESCRIPTION
Bond [5.1.0][1] added support for .NET Standard 1.0, 1.3, and 1.6.

[1]: https://github.com/Microsoft/bond/blob/master/CHANGELOG.md#510-2016-11-14
